### PR TITLE
Enable more power for loop; Send before call; simple.flow; Add super …

### DIFF
--- a/test/fixtures/forloop.flow
+++ b/test/fixtures/forloop.flow
@@ -1,0 +1,29 @@
+#  x = 10
+#  for i in range(5):
+#    x = x+3
+#  print(x)
+FLOW:
+  X:
+    CALLERS: SWITCHON
+    TASK:
+      DEFAULT: 10
+  PLUS3:
+    CALLERS:
+      - X | PLUS3
+      - COUNTER.C/True
+    SENDERS: X | PLUS3
+    TASK:
+      ADD: 3
+  COUNTER:
+    CALLERS: SWITCHON | PLUS3
+    SENDERS: COUNTER.C/True=V
+    TASK:
+      - DEFAULT: 0
+      - ADD: 1
+      - LESS_EQUAL: 5
+  TERMINAL:
+    CALLERS: COUNTER.C/False
+    SENDERS: PLUS3
+    TASK: DUMMY
+    END: true
+    EXPORT: [PRINT, RETURN]

--- a/test/fixtures/simple.flow
+++ b/test/fixtures/simple.flow
@@ -8,7 +8,7 @@ FLOW:
     TASK:
       CONSTANT:
         VALUE: 2
-    CALLERS: SWITCHON | IF_1.C/False=V
+    CALLERS: SWITCHON
   ADD_1:
     TASK:
       ADD_VALUE:
@@ -32,7 +32,7 @@ FLOW:
       LIST_ADD_SUM
     SENDERS:
       - CONSTANT_1
-      - CONSTANT_2
+      - CONSTANT_2 | IF_1.C/False=V
       - ADD_1
       - ADD
       - ADD: TIMES_1


### PR DESCRIPTION
Enable more power for loop; Send before call; simple.flow; Add super init suggested by pylint

Enable more power for loop
--------------------------

Before, the condition and the next value can only be from the
same node, like in simple.flow

```python
while x < 200:
   # pass x to other nodes
   ...
```

or condition from one node, and the next value is not used,
like in covtype.flow

```python
for _ in range(2):
   x = read_data()
   ...
```

Condition from one node, value from another node is not easy to
obtain.

I added an example for a for loop, in forloop.flow

```python
x = 10
for _ in range(5):
  x = x+3
print(x)
return x
```

To enable this, one crucial logic is modified. The last node to
print and return should be able to obtain the LATEST output of
the plus node, so when the for-loop node is done (and trigger
the return node), the return will print the latest value 25
rather than the first value 13 passed from the plus node.

See line 925 to 930 in utensil/loopflow/loopflow.py.

Send before call
----------------

This is a potential bug.

Must send before trigger because
receivers wait for callers but callees do not wait for senders.
That is, it might happen that receiver got triggered before sender ready.
For example, A triggers B, B triggers C, and A send C.
If trigger before send, after A ready,
C might get triggered by B (triggered by A) before A send C.

Fix simple.flow
---------------

simple.flow has some bugs.

ADD node receives B from CONSTANT_2 or IF_1.C/False=V, but CONSTANT_2 and IF_1
can both send some different values to ADD. So the actual behavior does not
match the intended one. Fixed the flow file and the corrosponding
test case expected value.


Add super init suggested by pylint
----------------------------------

Add super init in test_loopflow.py suggested by pylint.